### PR TITLE
fix broken sdist output

### DIFF
--- a/SDL2-ttf.cabal
+++ b/SDL2-ttf.cabal
@@ -10,6 +10,7 @@ Category:           Foreign binding
 Synopsis:           Binding to libSDL2-ttf
 Description:        Haskell bindings to the sdl2-ttf C++ library <http://www.libsdl.org/projects/SDL_ttf/>.
 Data-files:
+extra-source-files: cbits/rendering.h
 
 Library
   Hs-source-dirs:   src


### PR DESCRIPTION
The hackage upload is currently broken.  The header file `cbits/rendering.h` is not included in the tar file.  I "fixed" this issue by adding "cbits/rendering.h" to `extra-source-files`.
