### PR TITLE
Fix sdl2-ttf for sdl2-2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cabal-dev
 .hpc
 .hsenv
 .cabal-sandbox/
+.stack-work/
 cabal.sandbox.config
 cabal.config
 *.prof

--- a/examples/font_test.hs
+++ b/examples/font_test.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import qualified Graphics.UI.SDL.TTF as TTF
-import qualified Graphics.UI.SDL     as SDL
+import qualified SDL.Raw             as SDL
 
 import Foreign.C.String (withCAString)
 import Foreign (peek,alloca,with,maybePeek,nullPtr)

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -12,7 +12,7 @@ Description:        Haskell bindings to the sdl2-ttf C++ library <http://www.lib
 Data-files:
 extra-source-files: cbits/rendering.h
                     examples/ARIAL.TTF
-		    examples/font_test.c
+                    examples/font_test.c
 
 Library
   Hs-source-dirs:     src

--- a/src/Graphics/UI/SDL/TTF.hsc
+++ b/src/Graphics/UI/SDL/TTF.hsc
@@ -38,7 +38,7 @@ import Graphics.UI.SDL.TTF.FFI (TTFFont)
 
 import qualified Graphics.UI.SDL.TTF.FFI as FFI
 import Graphics.UI.SDL.TTF.Types
-import Graphics.UI.SDL.Types
+import SDL.Raw.Types
 
 import Prelude hiding (init)
 

--- a/src/Graphics/UI/SDL/TTF/FFI.hsc
+++ b/src/Graphics/UI/SDL/TTF/FFI.hsc
@@ -4,8 +4,8 @@ module Graphics.UI.SDL.TTF.FFI where
 import Foreign.C
 import Foreign.Ptr
 
-import qualified Graphics.UI.SDL.Types as SDL
-import Graphics.UI.SDL.Types (Color)
+import qualified SDL.Raw.Types as SDL
+import SDL.Raw.Types (Color)
 
 type TTFFont = Ptr ()
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: nightly-2015-09-24


### PR DESCRIPTION
sdl2 changes its module names around starting in 2.0.0., which causes this package to fail its build.
This patch does the following: 
- Renames sdl2 imports until it builds using sdl2-2.0.0. 
- Adds a stack.yaml for those using stack.
- Renames cabal file so it correlates with the package name (stack complains about this otherwise).
- Swaps an outstanding tab for a space in the cabal file.
