### PR TITLE
Update to new haskell-game/sdl2 >= 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.0.0 -- Tue 12 Jan 16 Rongcui Dong <karl_1702@188.com>
+* Completely upgraded API to the new high level haskell-game/sdl2 >=
+  2.0.0 ones.
+* Upgraded test suite to reflect
+
 0.2.0 -- Mon 5 Jan 2015
 * Changed SDL2 lib dependency to haskell-game/sdl2 (sdl2 on hackage)
 * Updated Test executable to suit new dependency.

--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,35 @@
-Copyright (c) 2013 Ömer Sinan Ağacan
+Copyright (c) Rongcui Dong 2015
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Original author: (c) 2013 Ömer Sinan Ağacan
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Sublicensed from original MIT License. A copy of original license is
+available in source distribution
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Rongcui Dong nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Ömer Sinan Ağacan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,21 +3,12 @@ sdl2-ttf
 
 Haskell bindings for the True Type Font library for SDL.
 
-- libsdl (https://www.libsdl.org)
-- sdl2-ttf (https://www.libsdl.org/projects/SDL_ttf/)
+- libsdl <https://www.libsdl.org>
+- sdl2-ttf <https://www.libsdl.org/projects/SDL_ttf/>
 
 I am not the original author of this library, credit for that goes
-to @osa1 and friends. Their version was dependent on a different implementation
-of Haskell SDL2 bindings. My needs were different as I am using the `sdl2`
-package from Hackage.
+to @osa1 and @mankyKitty. Their version was dependent on a different implementation
+of Haskell SDL2 bindings.
 
-I could not find a suitable sdl2-ttf library so I forked the `hsSDL2-ttf`
-implementation and here we are.
-
-Tests and further functionality will be added over time. 
-
-This is pretty much an alpha release. :<
-
-Hopefully it will be considered good enough to go up on hackage!
-
-Pull requests, suggestions, advice, feature requests are all invited!
+I forked `sdl2-ttf` haskell binding again to codevelop with my
+`timeless-SDL` project, and hopefully make it really high level

--- a/examples/font_test.hs
+++ b/examples/font_test.hs
@@ -1,23 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import qualified Graphics.UI.SDL.TTF as TTF
-import qualified SDL.Raw             as SDL
+import qualified SDL.TTF as TTF
+import qualified SDL.Raw             as Raw
+import qualified SDL as SDL
 
 import Foreign.C.String (withCAString)
 import Foreign (peek,alloca,with,maybePeek,nullPtr)
+
+import Linear.V2
+import Linear.Affine (Point(..))
 
 arial :: String
 arial = "./examples/ARIAL.TTF"
 
 main :: IO ()
 main = do
-    _ <- SDL.init SDL.SDL_INIT_VIDEO
-    window <- createWindow
-    renderer <- createRenderer window
+    _ <- SDL.initialize [SDL.InitVideo]
+    window <- SDL.createWindow "Test" SDL.defaultWindow
+    renderer <- SDL.createRenderer window 0 SDL.defaultRenderer
 
     TTF.withInit $ do
       font <- TTF.openFont arial 150 -- Pt size for retina screen. :<
-      textSurface <- TTF.renderUTF8Solid font "some text" (SDL.Color 255 255 255 0)
+      textSurface <- TTF.renderUTF8Solid font "some text" (Raw.Color 255 255 255 0)
       textTexture <- SDL.createTextureFromSurface renderer textSurface
       SDL.freeSurface textSurface
       loop window renderer textTexture
@@ -27,9 +32,10 @@ main = do
       SDL.destroyWindow window
       SDL.quit
 
-createRenderer :: SDL.Window -> IO (SDL.Renderer)
-createRenderer w = SDL.createRenderer w (-1) 0
+--createRenderer :: SDL.Window -> IO (SDL.Renderer)
+--createRenderer w = SDL.createRenderer w (-1) 0
 
+{-
 createWindow :: IO (SDL.Window)
 createWindow = withCAString "test" $ \t ->
       SDL.createWindow t
@@ -37,26 +43,28 @@ createWindow = withCAString "test" $ \t ->
         SDL.SDL_WINDOWPOS_UNDEFINED
         640 480
         SDL.SDL_WINDOW_SHOWN
+-}
 
 loop :: t -> SDL.Renderer -> SDL.Texture -> IO ()
 loop window renderer textTexture = do
-    let loc = SDL.Rect 320 240 150 100
-    _ <- SDL.renderClear renderer
-    _ <- with loc $ \loc' ->
-             SDL.renderCopy renderer textTexture nullPtr loc'
-    SDL.renderPresent renderer
+    let loc = SDL.Rectangle (P $ V2 320 240) (V2 150 100)
+    SDL.clear renderer
+    SDL.copy renderer textTexture Nothing (Just loc)
+    SDL.present renderer
     handleEvents window renderer textTexture
 
+{-
 pollEvent :: IO (Maybe SDL.Event)
 pollEvent = alloca $ \ptr -> do
   status <- SDL.pollEvent ptr
   if status == 1
     then maybePeek peek ptr
     else return Nothing
+-}
 
 handleEvents :: t -> SDL.Renderer -> SDL.Texture -> IO ()
 handleEvents window renderer textTexture = do
-  mbEvent <- pollEvent
+  mbEvent <- SDL.pollEvent
   case mbEvent of
-    Just (SDL.QuitEvent _ _) -> return ()
+    Just (SDL.Event _ SDL.QuitEvent) -> return ()
     _ -> loop window renderer textTexture

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -1,8 +1,9 @@
 Cabal-Version:      >= 1.10
 Name:               sdl2-ttf
 Version:            0.2.2
-Maintainer:         Sean Chalmers (sclhiannan@gmail.com)
+Maintainer:         Rongcui Dong (karl_1702@188.com)
 Author:             Ömer Sinan Ağacan (omeragacan@gmail.com)
+                  , Sean Chalmers (sclhiannan@gmail.com)
 License-File:       LICENSE
 License:            MIT
 Build-Type:         Simple
@@ -16,7 +17,7 @@ extra-source-files: cbits/rendering.h
 
 Library
   Hs-source-dirs:     src
-  Build-Depends:      base >= 3 && < 5, sdl2
+  Build-Depends:      base >= 3 && < 5, sdl2 >= 2
   default-extensions: ForeignFunctionInterface
   Exposed-Modules:    Graphics.UI.SDL.TTF.Types,
                       Graphics.UI.SDL.TTF.FFI
@@ -27,12 +28,12 @@ Library
   extra-libraries:    SDL2, SDL2_ttf
   default-language:   Haskell2010
 
-executable font-test
-  main-is:          font_test.hs
-  hs-source-dirs:   examples
-  build-depends:    base >= 3 && <5, sdl2, sdl2-ttf
-  GHC-Options:      -Wall
-  default-language: Haskell2010
+-- executable font-test
+--   main-is:          font_test.hs
+--   hs-source-dirs:   examples
+--   build-depends:    base >= 3 && <5, sdl2, sdl2-ttf
+--   GHC-Options:      -Wall
+--   default-language: Haskell2010
 
 source-repository head
     type:     git

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -17,7 +17,7 @@ extra-source-files: cbits/rendering.h
 
 Library
   Hs-source-dirs:     src
-  Build-Depends:      base >= 3 && < 5, sdl2 >= 2
+  Build-Depends:      base >= 3 && < 5, sdl2 >= 2, transformers
   default-extensions: ForeignFunctionInterface
   Exposed-Modules:    SDL.TTF.Types,
                       SDL.TTF.FFI
@@ -38,4 +38,4 @@ executable font-test
 
 source-repository head
     type:     git
-    location: https://github.com/mankyKitty/sdl2-ttf
+    location: https://github.com/carldong/sdl2-ttf

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:      >= 1.10
 Name:               sdl2-ttf
-Version:            0.2.2
+Version:            1.0.0
 Maintainer:         Rongcui Dong (karl_1702@188.com)
 Author:             Ömer Sinan Ağacan (omeragacan@gmail.com)
                   , Sean Chalmers (sclhiannan@gmail.com)
@@ -19,21 +19,22 @@ Library
   Hs-source-dirs:     src
   Build-Depends:      base >= 3 && < 5, sdl2 >= 2
   default-extensions: ForeignFunctionInterface
-  Exposed-Modules:    Graphics.UI.SDL.TTF.Types,
-                      Graphics.UI.SDL.TTF.FFI
-                      Graphics.UI.SDL.TTF
+  Exposed-Modules:    SDL.TTF.Types,
+                      SDL.TTF.FFI
+                      SDL.TTF
+  other-modules:      SDL.TTF.Internals
   GHC-Options:        -Wall
   include-dirs:       cbits
   C-sources:          cbits/rendering.c
   extra-libraries:    SDL2, SDL2_ttf
   default-language:   Haskell2010
 
--- executable font-test
---   main-is:          font_test.hs
---   hs-source-dirs:   examples
---   build-depends:    base >= 3 && <5, sdl2, sdl2-ttf
---   GHC-Options:      -Wall
---   default-language: Haskell2010
+executable font-test
+  main-is:          font_test.hs
+  hs-source-dirs:   examples
+  build-depends:    base >= 3 && <5, sdl2, sdl2-ttf, linear
+  GHC-Options:      -Wall
+  default-language: Haskell2010
 
 source-repository head
     type:     git

--- a/src/Graphics/UI/SDL/TTF.hsc
+++ b/src/Graphics/UI/SDL/TTF.hsc
@@ -34,11 +34,15 @@ import Foreign.Ptr
 import Control.Monad
 import Data.Int
 
+import qualified SDL as SDL
+import qualified SDL.Raw as Raw
+import SDL.Raw (Color(..))
+
 import Graphics.UI.SDL.TTF.FFI (TTFFont)
 
 import qualified Graphics.UI.SDL.TTF.FFI as FFI
 import Graphics.UI.SDL.TTF.Types
-import SDL.Raw.Types
+-- import SDL.Raw.Types
 
 import Prelude hiding (init)
 
@@ -280,81 +284,82 @@ sizeUNICODE = peekInts FFI.sizeUNICODE
 renderTextSolid :: TTFFont          -- ^ Font 
                 -> String           -- ^ The LATIN1 null terminated string to render.
                 -> Color            -- ^ The color to render the text in. Colormap index 1.
-                -> IO (Ptr Surface) -- ^ Pointer to a new SDL_Surface. NULL is returned on errors.
+                -> IO SDL.Surface -- ^ The returned high level SDL.Surface
 renderTextSolid fontPtr text fg = withCString text $ \cstr -> do
-    with fg $ \colorPtr -> FFI.renderTextSolid fontPtr cstr colorPtr
+    --with fg $ \colorPtr -> FFI.renderTextSolid fontPtr cstr colorPtr
+    with fg $ \colorPtr -> unmanagedSurface <$> FFI.renderTextSolid fontPtr cstr colorPtr
     
--- | Render the LATIN1 encoded text, using the Shaded mode
---
--- Render the LATIN1 encoded text using font with fg color onto a new surface,
--- using the Shaded mode.
---
--- @The caller (you!) is responsible for freeing any returned surface.@
-renderTextShaded :: TTFFont          -- ^ Font 
-                 -> String           -- ^ The LATIN1 null terminated string to render.
-                 -> Color            -- ^ The color to render the text in. Colormap index 1.
-                 -> Color            -- ^ The color to render the background box in. Colormap index 0.
-                 -> IO (Ptr Surface) -- ^ Pointer to a new SDL_Surface. NULL is returned on errors.
-renderTextShaded fontPtr text fg bg = withCString text $ \cstr ->
-    with fg $ \fgColorPtr ->
-      with bg $ \bgColorPtr ->
-        FFI.renderTextShaded fontPtr cstr fgColorPtr bgColorPtr
-
--- | Render the LATIN1 encoded text, using the Blended mode
---
--- Render the LATIN1 encoded text using font with fg color onto a new surface,
--- using the Blended mode.
---
--- @The caller (you!) is responsible for freeing any returned surface.@
-renderTextBlended :: TTFFont          -- ^ Font 
-                  -> String           -- ^ The LATIN1 null terminated string to render.
-                  -> Color            -- ^ The color to render the text in. Colormap index 1.
-                  -> IO (Ptr Surface) -- ^ Pointer to a new SDL_Surface. NULL is returned on errors.
-renderTextBlended fontPtr text color = withCString text $ \cstr ->
-    with color $ \colorPtr -> FFI.renderTextBlended fontPtr cstr colorPtr
-
--- | Render the UTF8 encoded text, using the Solid mode
---
--- Render the UTF8 encoded text using font with fg color onto a new surface,
--- using the Solid mode.
---
--- @The caller (you!) is responsible for freeing any returned surface.@
-renderUTF8Solid :: TTFFont            -- ^ Font 
-                  -> String           -- ^ The UTF8 null terminated string to render.
-                  -> Color            -- ^ The color to render the text in. Colormap index 1.
-                  -> IO (Ptr Surface) -- ^ Pointer to a new SDL_Surface. NULL is returned on errors.
-renderUTF8Solid fontPtr text fg = withCString text $ \cstr -> do
-    with fg $ \colorPtr -> FFI.renderUTF8Solid fontPtr cstr colorPtr
-    
--- | Render the UTF8 encoded text, using the Shaded mode
---
--- Render the UTF8 encoded text using font with fg color onto a new surface,
--- using the Shaded mode.
---
--- @The caller (you!) is responsible for freeing any returned surface.@
-renderUTF8Shaded :: TTFFont          -- ^ Font 
-                 -> String           -- ^ The UTF8 null terminated string to render.
-                 -> Color            -- ^ The color to render the text in. Colormap index 1.
-                 -> Color            -- ^ The color to render the background box in. Colormap index 0.
-                 -> IO (Ptr Surface) -- ^ Pointer to a new SDL_Surface. NULL is returned on errors.
-renderUTF8Shaded fontPtr text fg bg = withCString text $ \cstr ->
-    with fg $ \fgColorPtr ->
-      with bg $ \bgColorPtr ->
-        FFI.renderUTF8Shaded fontPtr cstr fgColorPtr bgColorPtr
-
--- | Render the UTF8 encoded text, using the Blended mode
---
--- Render the UTF8 encoded text using font with fg color onto a new surface,
--- using the Blended mode.
---
--- @The caller (you!) is responsible for freeing any returned surface.@
-renderUTF8Blended :: TTFFont          -- ^ Font 
-                  -> String           -- ^ The UTF8 null terminated string to render.
-                  -> Color            -- ^ The color to render the text in. Colormap index 1.
-                  -> IO (Ptr Surface) -- ^ Pointer to a new SDL_Surface. NULL is returned on errors.
-renderUTF8Blended fontPtr text color = withCString text $ \cstr ->
-    with color $ \colorPtr -> FFI.renderUTF8Blended fontPtr cstr colorPtr
-
+-- -- | Render the LATIN1 encoded text, using the Shaded mode
+-- --
+-- -- Render the LATIN1 encoded text using font with fg color onto a new surface,
+-- -- using the Shaded mode.
+-- --
+-- -- @The caller (you!) is responsible for freeing any returned surface.@
+-- renderTextShaded :: TTFFont          -- ^ Font 
+--                  -> String           -- ^ The LATIN1 null terminated string to render.
+--                  -> Color            -- ^ The color to render the text in. Colormap index 1.
+--                  -> Color            -- ^ The color to render the background box in. Colormap index 0.
+--                  -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+-- renderTextShaded fontPtr text fg bg = withCString text $ \cstr ->
+--     with fg $ \fgColorPtr ->
+--       with bg $ \bgColorPtr ->
+--         FFI.renderTextShaded fontPtr cstr fgColorPtr bgColorPtr
+-- 
+-- -- | Render the LATIN1 encoded text, using the Blended mode
+-- --
+-- -- Render the LATIN1 encoded text using font with fg color onto a new surface,
+-- -- using the Blended mode.
+-- --
+-- -- @The caller (you!) is responsible for freeing any returned surface.@
+-- renderTextBlended :: TTFFont          -- ^ Font 
+--                   -> String           -- ^ The LATIN1 null terminated string to render.
+--                   -> Color            -- ^ The color to render the text in. Colormap index 1.
+--                   -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+-- renderTextBlended fontPtr text color = withCString text $ \cstr ->
+--     with color $ \colorPtr -> FFI.renderTextBlended fontPtr cstr colorPtr
+-- 
+-- -- | Render the UTF8 encoded text, using the Solid mode
+-- --
+-- -- Render the UTF8 encoded text using font with fg color onto a new surface,
+-- -- using the Solid mode.
+-- --
+-- -- @The caller (you!) is responsible for freeing any returned surface.@
+-- renderUTF8Solid :: TTFFont            -- ^ Font 
+--                   -> String           -- ^ The UTF8 null terminated string to render.
+--                   -> Color            -- ^ The color to render the text in. Colormap index 1.
+--                   -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+-- renderUTF8Solid fontPtr text fg = withCString text $ \cstr -> do
+--     with fg $ \colorPtr -> FFI.renderUTF8Solid fontPtr cstr colorPtr
+--     
+-- -- | Render the UTF8 encoded text, using the Shaded mode
+-- --
+-- -- Render the UTF8 encoded text using font with fg color onto a new surface,
+-- -- using the Shaded mode.
+-- --
+-- -- @The caller (you!) is responsible for freeing any returned surface.@
+-- renderUTF8Shaded :: TTFFont          -- ^ Font 
+--                  -> String           -- ^ The UTF8 null terminated string to render.
+--                  -> Color            -- ^ The color to render the text in. Colormap index 1.
+--                  -> Color            -- ^ The color to render the background box in. Colormap index 0.
+--                  -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+-- renderUTF8Shaded fontPtr text fg bg = withCString text $ \cstr ->
+--     with fg $ \fgColorPtr ->
+--       with bg $ \bgColorPtr ->
+--         FFI.renderUTF8Shaded fontPtr cstr fgColorPtr bgColorPtr
+-- 
+-- -- | Render the UTF8 encoded text, using the Blended mode
+-- --
+-- -- Render the UTF8 encoded text using font with fg color onto a new surface,
+-- -- using the Blended mode.
+-- --
+-- -- @The caller (you!) is responsible for freeing any returned surface.@
+-- renderUTF8Blended :: TTFFont          -- ^ Font 
+--                   -> String           -- ^ The UTF8 null terminated string to render.
+--                   -> Color            -- ^ The color to render the text in. Colormap index 1.
+--                   -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+-- renderUTF8Blended fontPtr text color = withCString text $ \cstr ->
+--     with color $ \colorPtr -> FFI.renderUTF8Blended fontPtr cstr colorPtr
+-- 
 peekInts 
   :: (FFI.TTFFont -> CString -> Ptr CInt -> Ptr CInt -> IO CInt)
   -> TTFFont
@@ -368,3 +373,8 @@ peekInts fn fontPtr text = do
         w <- peek wPtr
         h <- peek hPtr
         return (fromIntegral w, fromIntegral h)
+
+-- | Straight from the code of "sdl2" package, which is not exported. It will make a high level Surface from a Raw Surface. I will move this to somewhere safe, soon
+unmanagedSurface :: Ptr Raw.Surface -> SDL.Surface
+unmanagedSurface s = SDL.Surface s Nothing
+

--- a/src/SDL/TTF.hsc
+++ b/src/SDL/TTF.hsc
@@ -44,6 +44,7 @@ import qualified SDL.TTF.FFI as FFI
 import SDL.TTF.Types
 import SDL.TTF.Internals
 
+import Control.Monad.IO.Class
 import Prelude hiding (init)
 
 -- | Initialize the truetype font API.
@@ -52,30 +53,30 @@ import Prelude hiding (init)
 --
 -- SDL does not have to be initialized before this call.
 -- Returns: 0 on success, -1 on any error.
-init :: IO CInt
-init = FFI.init
+init :: MonadIO m => m CInt
+init = liftIO $ FFI.init
 
 -- | Query if TTF API has been initialised.
 -- Query the initilization status of the truetype font API.
 -- You may, of course, use this before TTF_Init to avoid
 -- initializing twice in a row. Or use this to determine if you
 -- need to call TTF_Quit.
-wasInit :: IO Bool
-wasInit = FFI.init >>= return . (==1)
+wasInit :: MonadIO m => m Bool
+wasInit = liftIO $ FFI.init >>= return . (==1)
 
 -- | Shut down the TTF system.
 -- Shutdown and cleanup the truetype font API.
 -- After calling this the SDL_ttf functions should not be used,
 -- excepting TTF_WasInit. You may, of course, use TTF_Init to use
 -- the functionality again.
-quit :: IO ()
-quit = FFI.quit
+quit :: MonadIO m => m ()
+quit = liftIO $ FFI.quit
 
 -- | Initialise the TTF system, run the given action(s), then quit TTF.
 -- This function handles the initialisation and shut down of the TTF system
 -- however if the initialisation fails an exception will be thrown and 
 -- your program will crash.
-withInit :: IO a -> IO a
+withInit :: MonadIO m => m a -> m a
 withInit a = do
   ret <- init >> a
   quit
@@ -86,29 +87,29 @@ withInit a = do
 -- This basically translates to pixel height. Equivalent to TTF_OpenFontIndex(file, ptsize, 0).
 -- It can also can load TTF and FON files.
 -- 
-openFont :: String     -- ^ File name to load font from.
+openFont :: MonadIO m => String     -- ^ File name to load font from.
          -> Int        -- ^ Point size (based on 72DPI) to load font as.
-         -> IO TTFFont -- ^ Pointer to the font as a TTF_Font. NULL is returned on errors.
-openFont file ptsize = withCString file $ \cstr ->
+         -> m TTFFont -- ^ Pointer to the font as a TTF_Font. NULL is returned on errors.
+openFont file ptsize = liftIO $ withCString file $ \cstr ->
     FFI.openFont cstr (fromIntegral ptsize)
 
 -- | Free the memory used by font, and free font itself as well.
 --
 -- @Do not use font after this without loading a new font to it.@
-closeFont :: TTFFont -- ^ Font to be freed.
-          -> IO ()
-closeFont fontPtr = FFI.closeFont fontPtr
+closeFont :: MonadIO m => TTFFont -- ^ Font to be freed.
+          -> m ()
+closeFont fontPtr = liftIO $ FFI.closeFont fontPtr
 
 -- | Load file, face index, for use as a font, at ptsize size.
 --
 -- This is equivalent to TTF_OpenFontIndexRW(SDL_RWFromFile(file), ptsize, index),
 -- but checks that the RWops it creates is not NULL. This can load TTF and FON files.
 --
-openFontIndex :: String      -- ^ File name to load font from.
+openFontIndex :: MonadIO m => String      -- ^ File name to load font from.
               -> Int         -- ^ Point size (based on 72DPI) to load font as.
               -> Int         -- ^ Font face index. The first face is always index 0.
-              -> IO TTFFont  -- ^ Pointer to the font as a TTF_Font.
-openFontIndex file ptsize index = withCString file $ \cstr -> 
+              -> m TTFFont  -- ^ Pointer to the font as a TTF_Font.
+openFontIndex file ptsize index = liftIO $ withCString file $ \cstr -> 
   FFI.openFontIndex cstr (fromIntegral ptsize) (fromIntegral index)
 
 -- | Get the rendering style of the loaded font.
@@ -116,9 +117,9 @@ openFontIndex file ptsize index = withCString file $ \cstr ->
 -- If no style is set then TTF_STYLE_NORMAL is returned.
 --
 -- @Extra pointers: <http://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC21>@
-getFontStyle :: TTFFont     -- ^ Font
-             -> IO TTFStyle -- ^ Current style bitmask of the font.
-getFontStyle fontPtr = liftM (toEnum . fromIntegral) $ FFI.getFontStyle fontPtr
+getFontStyle :: MonadIO m => TTFFont     -- ^ Font
+             -> m TTFStyle -- ^ Current style bitmask of the font.
+getFontStyle fontPtr = liftIO $ liftM (toEnum . fromIntegral) $ FFI.getFontStyle fontPtr
 
 -- | Set the rendering style of the loaded font.
 --
@@ -127,17 +128,17 @@ getFontStyle fontPtr = liftM (toEnum . fromIntegral) $ FFI.getFontStyle fontPtr
 -- the current style using TTF_GetFontStyle first.
 --
 -- @Extra pointers: <http://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC22>@
-setFontStyle :: TTFFont     -- ^ Font 
+setFontStyle :: MonadIO m => TTFFont     -- ^ Font 
              -> TTFStyle    -- ^ The style as a bitmask
-             -> IO ()
-setFontStyle fontPtr style = FFI.setFontStyle fontPtr (fromIntegral $ fromEnum style)
+             -> m ()
+setFontStyle fontPtr style = liftIO $ FFI.setFontStyle fontPtr (fromIntegral $ fromEnum style)
 
 -- | Get the current hinting setting of the loaded font.
 --
 -- If no hinting is set then TTF_HINTING_NORMAL is returned.
-getFontHinting :: TTFFont       -- ^ Font 
-               -> IO TTFHinting -- ^ The current hinting setting of the loaded font.
-getFontHinting fontPtr = liftM (toEnum . fromIntegral) $ FFI.getFontHinting fontPtr
+getFontHinting :: MonadIO m => TTFFont       -- ^ Font 
+               -> m TTFHinting -- ^ The current hinting setting of the loaded font.
+getFontHinting fontPtr = liftIO $ liftM (toEnum . fromIntegral) $ FFI.getFontHinting fontPtr
 
 -- | Set the hinting of the loaded font.
 --
@@ -145,10 +146,10 @@ getFontHinting fontPtr = liftM (toEnum . fromIntegral) $ FFI.getFontHinting font
 -- are using beforehand, especially when using smaller sized fonts.
 -- If the user is selecting a font, you may wish to let them select the
 -- hinting mode for that font as well.
-setFontHinting :: TTFFont    -- ^ Font 
+setFontHinting :: MonadIO m => TTFFont    -- ^ Font 
                -> TTFHinting -- ^ The hinting setting desired.
-               -> IO ()
-setFontHinting fontPtr hinting = FFI.setFontHinting fontPtr (fromIntegral $ fromEnum hinting)
+               -> m ()
+setFontHinting fontPtr hinting = liftIO $ FFI.setFontHinting fontPtr (fromIntegral $ fromEnum hinting)
 
 -- | Get the maximum pixel height of all glyphs of the loaded font.
 --
@@ -156,9 +157,9 @@ setFontHinting fontPtr hinting = FFI.setFontHinting fontPtr (fromIntegral $ from
 -- as possible, though adding at least one pixel height to it will space it
 -- so they can't touch. Remember that SDL_ttf doesn't handle multiline
 -- printing, so you are responsible for line spacing, see the TTF_FontLineSkip as well.
-getFontHeight :: TTFFont  -- ^ Font 
-              -> IO Int   -- ^ Maximum pixel height of all glyphs in the font.
-getFontHeight fontPtr = liftM fromIntegral $ FFI.getFontHeight fontPtr
+getFontHeight :: MonadIO m => TTFFont  -- ^ Font 
+              -> m Int   -- ^ Maximum pixel height of all glyphs in the font.
+getFontHeight fontPtr = liftIO $ liftM fromIntegral $ FFI.getFontHeight fontPtr
 
 -- | Get the maximum pixel ascent of all glyphs of the loaded font. 
 --
@@ -170,9 +171,9 @@ getFontHeight fontPtr = liftM fromIntegral $ FFI.getFontHeight fontPtr
 -- Warning: C code (ewwwww)
 --
 -- @rect.y = top + TTF_FontAscent(font) - glyph_metric.maxy;@
-getFontAscent :: TTFFont  -- ^ Font 
-              -> IO Int   -- ^ Maximum pixel ascent of all glyphs in the font.
-getFontAscent fontPtr = liftM fromIntegral $ FFI.getFontAscent fontPtr
+getFontAscent :: MonadIO m => TTFFont  -- ^ Font 
+              -> m Int   -- ^ Maximum pixel ascent of all glyphs in the font.
+getFontAscent fontPtr = liftIO $ liftM fromIntegral $ FFI.getFontAscent fontPtr
 
 -- | Get the maximum pixel descent of all glyphs of the loaded font. 
 --
@@ -180,16 +181,16 @@ getFontAscent fontPtr = liftM fromIntegral $ FFI.getFontAscent fontPtr
 -- It could be used when drawing an individual glyph relative to a bottom point,
 -- by combining it with the glyph's maxy metric to resolve the top of the rectangle
 -- used when blitting the glyph on the screen.
-getFontDescent :: TTFFont  -- ^ Font  
-               -> IO Int   -- ^ Maximum pixel height of all glyphs in the font.
-getFontDescent fontPtr = liftM fromIntegral $ FFI.getFontDescent fontPtr
+getFontDescent :: MonadIO m => TTFFont  -- ^ Font  
+               -> m Int   -- ^ Maximum pixel height of all glyphs in the font.
+getFontDescent fontPtr = liftIO $ liftM fromIntegral $ FFI.getFontDescent fontPtr
 
 -- | Get the current kerning setting of the loaded font.
 --
 -- The default for a newly loaded font is enabled(True).
-fontKerningEnabled :: TTFFont           -- ^ Font
-                   -> IO KerningStatus  -- ^ Current Kerning status.
-fontKerningEnabled fontPtr = FFI.getFontKerning fontPtr >>= return . toKS
+fontKerningEnabled :: MonadIO m => TTFFont           -- ^ Font
+                   -> m KerningStatus  -- ^ Current Kerning status.
+fontKerningEnabled fontPtr = liftIO $ FFI.getFontKerning fontPtr >>= return . toKS
   where
     toKS 1 = KerningOn
     toKS _ = KerningOff
@@ -200,11 +201,11 @@ fontKerningEnabled fontPtr = FFI.getFontKerning fontPtr >>= return . toKS
 -- strings of characters, at least a word at a time. Perhaps the only time
 -- to disable this is when kerning is not working for a specific font,
 -- resulting in overlapping glyphs or abnormal spacing within words.
-setFontKerning :: TTFFont       -- ^ Font
+setFontKerning :: MonadIO m => TTFFont       -- ^ Font
                -> KerningStatus -- ^ Desired Kerning status.
-               -> IO ()
-setFontKerning fontPtr KerningOn  = FFI.setFontKerning fontPtr 1
-setFontKerning fontPtr KerningOff = FFI.setFontKerning fontPtr 0
+               -> m ()
+setFontKerning fontPtr KerningOn  = liftIO $ FFI.setFontKerning fontPtr 1
+setFontKerning fontPtr KerningOff = liftIO $ FFI.setFontKerning fontPtr 0
 
 -- | Get the number of faces ("sub-fonts") available in the loaded font.
 --
@@ -212,9 +213,9 @@ setFontKerning fontPtr KerningOff = FFI.setFontKerning fontPtr 0
 -- style and other typographical features perhaps) contained in the
 -- font itself. It seems to be a useless fact to know, since it can't
 -- be applied in any other SDL_ttf functions. 
-fontFaces :: TTFFont   -- ^ Font
-          -> IO Int64  -- ^ The number of faces in the font.
-fontFaces fontPtr = liftM fromIntegral $ FFI.fontFaces fontPtr
+fontFaces :: MonadIO m => TTFFont   -- ^ Font
+          -> m Int64  -- ^ The number of faces in the font.
+fontFaces fontPtr = liftIO $ liftM fromIntegral $ FFI.fontFaces fontPtr
 
 -- | Test if the current font face of the loaded font is a fixed width font.
 --
@@ -224,10 +225,10 @@ fontFaces fontPtr = liftM fromIntegral $ FFI.fontFaces fontPtr
 --
 -- @glyph_width * string_length@
 --
-fontFaceIsFixedWidth :: TTFFont       -- ^ Font
-                     -> IO FixedWidth -- ^ If font is a fixed width font.
+fontFaceIsFixedWidth :: MonadIO m => TTFFont       -- ^ Font
+                     -> m FixedWidth -- ^ If font is a fixed width font.
 fontFaceIsFixedWidth fontPtr =
-  FFI.fontFaceIsFixedWidth fontPtr >>= return . toFW
+  liftIO $ FFI.fontFaceIsFixedWidth fontPtr >>= return . toFW
   where
     toFW 1 = IsFixedW
     toFW _ = NotFixedW
@@ -236,43 +237,43 @@ fontFaceIsFixedWidth fontPtr =
 --
 -- This function may return a NULL pointer, in which case the information
 -- is not available. 
-fontFaceFamilyName :: TTFFont   -- ^ Font
-                   -> IO String -- ^ The current family name of of the face of the font, or NULL perhaps.
-fontFaceFamilyName fontPtr = FFI.fontFaceFamilyName fontPtr >>= peekCString
+fontFaceFamilyName :: MonadIO m => TTFFont   -- ^ Font
+                   -> m String -- ^ The current family name of of the face of the font, or NULL perhaps.
+fontFaceFamilyName fontPtr = liftIO $ FFI.fontFaceFamilyName fontPtr >>= peekCString
 
 -- | Get the current font face style name from the loaded font.
 --
 -- This function may return a NULL pointer, in which case the information
 -- is not available. 
-fontFaceStyleName :: TTFFont   -- ^ Font
-                  -> IO String -- ^ The current style name of of the face of the font, or NULL perhaps.
-fontFaceStyleName fontPtr = FFI.fontFaceStyleName fontPtr >>= peekCString
+fontFaceStyleName :: MonadIO m => TTFFont   -- ^ Font
+                  -> m String -- ^ The current style name of of the face of the font, or NULL perhaps.
+fontFaceStyleName fontPtr = liftIO $ FFI.fontFaceStyleName fontPtr >>= peekCString
 
 -- | Calculate the resulting surface size of the LATIN1 encoded text rendered using font.
 --
 -- No actual rendering is done, however correct kerning is done to get the actual
 -- width. The height returned in h is the same as you can get using @getFontHeight@. 
-sizeText :: TTFFont       -- ^ Font
+sizeText :: MonadIO m => TTFFont       -- ^ Font
          -> String        -- ^ The LATIN1 null terminated string to size up.
-         -> IO (Int, Int) -- ^ (Width,Height)
+         -> m (Int, Int) -- ^ (Width,Height)
 sizeText = peekInts FFI.sizeText
 
 -- | Calculate the resulting surface size of the UTF8 encoded text rendered using font.
 --
 -- No actual rendering is done, however correct kerning is done to get the actual width.
 -- The height returned in h is the same as you can get using @getFontHeight@. 
-sizeUTF8 :: TTFFont       -- ^ Font
+sizeUTF8 :: MonadIO m => TTFFont       -- ^ Font
          -> String        -- ^ The UTF8 null terminated string to size up.
-         -> IO (Int, Int) -- ^ (Width,Height)
+         -> m (Int, Int) -- ^ (Width,Height)
 sizeUTF8 = peekInts FFI.sizeUTF8
 
 -- | Calculate the resulting surface size of the UNICODE encoded text rendered using font.
 --
 -- No actual rendering is done, however correct kerning is done to get the actual width.
 -- The height returned in h is the same as you can get using @getFontHeight@. 
-sizeUNICODE :: TTFFont       -- ^ Font
+sizeUNICODE :: MonadIO m => TTFFont       -- ^ Font
             -> String        -- ^ The UNICODE null terminated string to size up.
-            -> IO (Int, Int) -- ^ (Width,Height)
+            -> m (Int, Int) -- ^ (Width,Height)
 sizeUNICODE = peekInts FFI.sizeUNICODE
 
 -- | Render the LATIN1 encoded text, using the Solid mode
@@ -281,11 +282,11 @@ sizeUNICODE = peekInts FFI.sizeUNICODE
 -- using the Solid mode.
 --
 -- @The caller (you!) is responsible for freeing any returned surface.@
-renderTextSolid :: TTFFont          -- ^ Font 
+renderTextSolid :: MonadIO m => TTFFont          -- ^ Font 
                 -> String           -- ^ The LATIN1 null terminated string to render.
                 -> Color            -- ^ The color to render the text in. Colormap index 1.
-                -> IO SDL.Surface -- ^ The returned high level SDL.Surface
-renderTextSolid fontPtr text fg = withCString text $ \cstr -> do
+                -> m SDL.Surface -- ^ The returned high level SDL.Surface
+renderTextSolid fontPtr text fg = liftIO $ withCString text $ \cstr -> do
     --with fg $ \colorPtr -> FFI.renderTextSolid fontPtr cstr colorPtr
     with fg $ \colorPtr -> unmanagedSurface <$> FFI.renderTextSolid fontPtr cstr colorPtr
 
@@ -295,12 +296,12 @@ renderTextSolid fontPtr text fg = withCString text $ \cstr -> do
 -- using the Shaded mode.
 --
 -- @The caller (you!) is responsible for freeing any returned surface.@
-renderTextShaded :: TTFFont          -- ^ Font 
+renderTextShaded :: MonadIO m => TTFFont          -- ^ Font 
                  -> String           -- ^ The LATIN1 null terminated string to render.
                  -> Color            -- ^ The color to render the text in. Colormap index 1.
                  -> Color            -- ^ The color to render the background box in. Colormap index 0.
-                 -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
-renderTextShaded fontPtr text fg bg = withCString text $ \cstr ->
+                 -> m SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderTextShaded fontPtr text fg bg = liftIO $ withCString text $ \cstr ->
     with fg $ \fgColorPtr ->
       with bg $ \bgColorPtr ->
         unmanagedSurface <$> FFI.renderTextShaded fontPtr cstr fgColorPtr bgColorPtr
@@ -311,11 +312,11 @@ renderTextShaded fontPtr text fg bg = withCString text $ \cstr ->
 -- using the Blended mode.
 --
 -- @The caller (you!) is responsible for freeing any returned surface.@
-renderTextBlended :: TTFFont          -- ^ Font 
+renderTextBlended :: MonadIO m => TTFFont          -- ^ Font 
                   -> String           -- ^ The LATIN1 null terminated string to render.
                   -> Color            -- ^ The color to render the text in. Colormap index 1.
-                  -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
-renderTextBlended fontPtr text color = withCString text $ \cstr ->
+                  -> m SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderTextBlended fontPtr text color = liftIO $ withCString text $ \cstr ->
     with color $ \colorPtr -> unmanagedSurface <$> FFI.renderTextBlended fontPtr cstr colorPtr
 
 -- | Render the UTF8 encoded text, using the Solid mode
@@ -324,11 +325,11 @@ renderTextBlended fontPtr text color = withCString text $ \cstr ->
 -- using the Solid mode.
 --
 -- @The caller (you!) is responsible for freeing any returned surface.@
-renderUTF8Solid :: TTFFont            -- ^ Font 
+renderUTF8Solid :: MonadIO m => TTFFont            -- ^ Font 
                   -> String           -- ^ The UTF8 null terminated string to render.
                   -> Color            -- ^ The color to render the text in. Colormap index 1.
-                  -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
-renderUTF8Solid fontPtr text fg = withCString text $ \cstr -> do
+                  -> m SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderUTF8Solid fontPtr text fg = liftIO $ withCString text $ \cstr -> do
     with fg $ \colorPtr -> unmanagedSurface <$> FFI.renderUTF8Solid fontPtr cstr colorPtr
     
 -- | Render the UTF8 encoded text, using the Shaded mode
@@ -337,12 +338,12 @@ renderUTF8Solid fontPtr text fg = withCString text $ \cstr -> do
 -- using the Shaded mode.
 --
 -- @The caller (you!) is responsible for freeing any returned surface.@
-renderUTF8Shaded :: TTFFont          -- ^ Font 
+renderUTF8Shaded :: MonadIO m => TTFFont          -- ^ Font 
                  -> String           -- ^ The UTF8 null terminated string to render.
                  -> Color            -- ^ The color to render the text in. Colormap index 1.
                  -> Color            -- ^ The color to render the background box in. Colormap index 0.
-                 -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
-renderUTF8Shaded fontPtr text fg bg = withCString text $ \cstr ->
+                 -> m SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderUTF8Shaded fontPtr text fg bg = liftIO $ withCString text $ \cstr ->
     with fg $ \fgColorPtr ->
       with bg $ \bgColorPtr ->
         unmanagedSurface <$> FFI.renderUTF8Shaded fontPtr cstr fgColorPtr bgColorPtr
@@ -353,10 +354,10 @@ renderUTF8Shaded fontPtr text fg bg = withCString text $ \cstr ->
 -- using the Blended mode.
 --
 -- @The caller (you!) is responsible for freeing any returned surface.@
-renderUTF8Blended :: TTFFont          -- ^ Font 
+renderUTF8Blended :: MonadIO m => TTFFont          -- ^ Font 
                   -> String           -- ^ The UTF8 null terminated string to render.
                   -> Color            -- ^ The color to render the text in. Colormap index 1.
-                  -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
-renderUTF8Blended fontPtr text color = withCString text $ \cstr ->
+                  -> m SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderUTF8Blended fontPtr text color = liftIO $ withCString text $ \cstr ->
     with color $ \colorPtr -> unmanagedSurface <$> FFI.renderUTF8Blended fontPtr cstr colorPtr
 

--- a/src/SDL/TTF.hsc
+++ b/src/SDL/TTF.hsc
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------
 -- |
--- Module      :  Graphics.UI.SDL.TTF
+-- Module      :  SDL.TTF
 --
 -- Introduction from SDL_ttf documentation at:
 -- <http://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html>
@@ -23,7 +23,7 @@
 -- 
 -- Enjoy! -Sam Lantinga slouken@devolution.com (5/1/98)
 -----------------------------------------------------------------------	
-module Graphics.UI.SDL.TTF where
+module SDL.TTF where
 
 import Foreign.C.String
 import Foreign.C.Types (CInt)
@@ -38,11 +38,11 @@ import qualified SDL as SDL
 import qualified SDL.Raw as Raw
 import SDL.Raw (Color(..))
 
-import Graphics.UI.SDL.TTF.FFI (TTFFont)
+import SDL.TTF.FFI (TTFFont)
 
-import qualified Graphics.UI.SDL.TTF.FFI as FFI
-import Graphics.UI.SDL.TTF.Types
--- import SDL.Raw.Types
+import qualified SDL.TTF.FFI as FFI
+import SDL.TTF.Types
+import SDL.TTF.Internals
 
 import Prelude hiding (init)
 
@@ -288,93 +288,75 @@ renderTextSolid :: TTFFont          -- ^ Font
 renderTextSolid fontPtr text fg = withCString text $ \cstr -> do
     --with fg $ \colorPtr -> FFI.renderTextSolid fontPtr cstr colorPtr
     with fg $ \colorPtr -> unmanagedSurface <$> FFI.renderTextSolid fontPtr cstr colorPtr
-    
--- -- | Render the LATIN1 encoded text, using the Shaded mode
--- --
--- -- Render the LATIN1 encoded text using font with fg color onto a new surface,
--- -- using the Shaded mode.
--- --
--- -- @The caller (you!) is responsible for freeing any returned surface.@
--- renderTextShaded :: TTFFont          -- ^ Font 
---                  -> String           -- ^ The LATIN1 null terminated string to render.
---                  -> Color            -- ^ The color to render the text in. Colormap index 1.
---                  -> Color            -- ^ The color to render the background box in. Colormap index 0.
---                  -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
--- renderTextShaded fontPtr text fg bg = withCString text $ \cstr ->
---     with fg $ \fgColorPtr ->
---       with bg $ \bgColorPtr ->
---         FFI.renderTextShaded fontPtr cstr fgColorPtr bgColorPtr
--- 
--- -- | Render the LATIN1 encoded text, using the Blended mode
--- --
--- -- Render the LATIN1 encoded text using font with fg color onto a new surface,
--- -- using the Blended mode.
--- --
--- -- @The caller (you!) is responsible for freeing any returned surface.@
--- renderTextBlended :: TTFFont          -- ^ Font 
---                   -> String           -- ^ The LATIN1 null terminated string to render.
---                   -> Color            -- ^ The color to render the text in. Colormap index 1.
---                   -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
--- renderTextBlended fontPtr text color = withCString text $ \cstr ->
---     with color $ \colorPtr -> FFI.renderTextBlended fontPtr cstr colorPtr
--- 
--- -- | Render the UTF8 encoded text, using the Solid mode
--- --
--- -- Render the UTF8 encoded text using font with fg color onto a new surface,
--- -- using the Solid mode.
--- --
--- -- @The caller (you!) is responsible for freeing any returned surface.@
--- renderUTF8Solid :: TTFFont            -- ^ Font 
---                   -> String           -- ^ The UTF8 null terminated string to render.
---                   -> Color            -- ^ The color to render the text in. Colormap index 1.
---                   -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
--- renderUTF8Solid fontPtr text fg = withCString text $ \cstr -> do
---     with fg $ \colorPtr -> FFI.renderUTF8Solid fontPtr cstr colorPtr
---     
--- -- | Render the UTF8 encoded text, using the Shaded mode
--- --
--- -- Render the UTF8 encoded text using font with fg color onto a new surface,
--- -- using the Shaded mode.
--- --
--- -- @The caller (you!) is responsible for freeing any returned surface.@
--- renderUTF8Shaded :: TTFFont          -- ^ Font 
---                  -> String           -- ^ The UTF8 null terminated string to render.
---                  -> Color            -- ^ The color to render the text in. Colormap index 1.
---                  -> Color            -- ^ The color to render the background box in. Colormap index 0.
---                  -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
--- renderUTF8Shaded fontPtr text fg bg = withCString text $ \cstr ->
---     with fg $ \fgColorPtr ->
---       with bg $ \bgColorPtr ->
---         FFI.renderUTF8Shaded fontPtr cstr fgColorPtr bgColorPtr
--- 
--- -- | Render the UTF8 encoded text, using the Blended mode
--- --
--- -- Render the UTF8 encoded text using font with fg color onto a new surface,
--- -- using the Blended mode.
--- --
--- -- @The caller (you!) is responsible for freeing any returned surface.@
--- renderUTF8Blended :: TTFFont          -- ^ Font 
---                   -> String           -- ^ The UTF8 null terminated string to render.
---                   -> Color            -- ^ The color to render the text in. Colormap index 1.
---                   -> IO (Ptr SDL.Surface) -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
--- renderUTF8Blended fontPtr text color = withCString text $ \cstr ->
---     with color $ \colorPtr -> FFI.renderUTF8Blended fontPtr cstr colorPtr
--- 
-peekInts 
-  :: (FFI.TTFFont -> CString -> Ptr CInt -> Ptr CInt -> IO CInt)
-  -> TTFFont
-  -> String
-  -> IO (Int,Int)
-peekInts fn fontPtr text = do
-    alloca $ \wPtr ->
-      alloca $ \hPtr -> do
-        -- TODO: handle errors
-        void $ withCString text $ \cstr -> fn fontPtr cstr wPtr hPtr
-        w <- peek wPtr
-        h <- peek hPtr
-        return (fromIntegral w, fromIntegral h)
 
--- | Straight from the code of "sdl2" package, which is not exported. It will make a high level Surface from a Raw Surface. I will move this to somewhere safe, soon
-unmanagedSurface :: Ptr Raw.Surface -> SDL.Surface
-unmanagedSurface s = SDL.Surface s Nothing
+-- | Render the LATIN1 encoded text, using the Shaded mode
+--
+-- Render the LATIN1 encoded text using font with fg color onto a new surface,
+-- using the Shaded mode.
+--
+-- @The caller (you!) is responsible for freeing any returned surface.@
+renderTextShaded :: TTFFont          -- ^ Font 
+                 -> String           -- ^ The LATIN1 null terminated string to render.
+                 -> Color            -- ^ The color to render the text in. Colormap index 1.
+                 -> Color            -- ^ The color to render the background box in. Colormap index 0.
+                 -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderTextShaded fontPtr text fg bg = withCString text $ \cstr ->
+    with fg $ \fgColorPtr ->
+      with bg $ \bgColorPtr ->
+        unmanagedSurface <$> FFI.renderTextShaded fontPtr cstr fgColorPtr bgColorPtr
+
+-- | Render the LATIN1 encoded text, using the Blended mode
+--
+-- Render the LATIN1 encoded text using font with fg color onto a new surface,
+-- using the Blended mode.
+--
+-- @The caller (you!) is responsible for freeing any returned surface.@
+renderTextBlended :: TTFFont          -- ^ Font 
+                  -> String           -- ^ The LATIN1 null terminated string to render.
+                  -> Color            -- ^ The color to render the text in. Colormap index 1.
+                  -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderTextBlended fontPtr text color = withCString text $ \cstr ->
+    with color $ \colorPtr -> unmanagedSurface <$> FFI.renderTextBlended fontPtr cstr colorPtr
+
+-- | Render the UTF8 encoded text, using the Solid mode
+--
+-- Render the UTF8 encoded text using font with fg color onto a new surface,
+-- using the Solid mode.
+--
+-- @The caller (you!) is responsible for freeing any returned surface.@
+renderUTF8Solid :: TTFFont            -- ^ Font 
+                  -> String           -- ^ The UTF8 null terminated string to render.
+                  -> Color            -- ^ The color to render the text in. Colormap index 1.
+                  -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderUTF8Solid fontPtr text fg = withCString text $ \cstr -> do
+    with fg $ \colorPtr -> unmanagedSurface <$> FFI.renderUTF8Solid fontPtr cstr colorPtr
+    
+-- | Render the UTF8 encoded text, using the Shaded mode
+--
+-- Render the UTF8 encoded text using font with fg color onto a new surface,
+-- using the Shaded mode.
+--
+-- @The caller (you!) is responsible for freeing any returned surface.@
+renderUTF8Shaded :: TTFFont          -- ^ Font 
+                 -> String           -- ^ The UTF8 null terminated string to render.
+                 -> Color            -- ^ The color to render the text in. Colormap index 1.
+                 -> Color            -- ^ The color to render the background box in. Colormap index 0.
+                 -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderUTF8Shaded fontPtr text fg bg = withCString text $ \cstr ->
+    with fg $ \fgColorPtr ->
+      with bg $ \bgColorPtr ->
+        unmanagedSurface <$> FFI.renderUTF8Shaded fontPtr cstr fgColorPtr bgColorPtr
+
+-- | Render the UTF8 encoded text, using the Blended mode
+--
+-- Render the UTF8 encoded text using font with fg color onto a new surface,
+-- using the Blended mode.
+--
+-- @The caller (you!) is responsible for freeing any returned surface.@
+renderUTF8Blended :: TTFFont          -- ^ Font 
+                  -> String           -- ^ The UTF8 null terminated string to render.
+                  -> Color            -- ^ The color to render the text in. Colormap index 1.
+                  -> IO SDL.Surface -- ^ Pointer to a new SDL_SDL.Surface. NULL is returned on errors.
+renderUTF8Blended fontPtr text color = withCString text $ \cstr ->
+    with color $ \colorPtr -> unmanagedSurface <$> FFI.renderUTF8Blended fontPtr cstr colorPtr
 

--- a/src/SDL/TTF/FFI.hsc
+++ b/src/SDL/TTF/FFI.hsc
@@ -1,5 +1,5 @@
 #include "SDL2/SDL_ttf.h"
-module Graphics.UI.SDL.TTF.FFI where
+module SDL.TTF.FFI where
 
 import Foreign.C
 import Foreign.Ptr

--- a/src/SDL/TTF/Internals.hsc
+++ b/src/SDL/TTF/Internals.hsc
@@ -3,24 +3,25 @@ module SDL.TTF.Internals where
 import Foreign.C.String
 import Foreign.C.Types (CInt)
 import Foreign.Marshal.Alloc
-import Foreign.Marshal.Utils
+-- import Foreign.Marshal.Utils()
 import Foreign.Storable
 import Foreign.Ptr
 import Control.Monad
+import Control.Monad.IO.Class
 
 import qualified SDL as SDL
 import qualified SDL.Raw as Raw
 
 --import SDL.TTF.FFI (TTFFont)
 import qualified SDL.TTF.FFI as FFI
-import SDL.TTF.Types
+--import SDL.TTF.Types
 
-peekInts 
-  :: (FFI.TTFFont -> CString -> Ptr CInt -> Ptr CInt -> IO CInt)
+peekInts :: MonadIO m =>
+     (FFI.TTFFont -> CString -> Ptr CInt -> Ptr CInt -> IO CInt)
   -> FFI.TTFFont
   -> String
-  -> IO (Int,Int)
-peekInts fn fontPtr text = do
+  -> m (Int,Int)
+peekInts fn fontPtr text = liftIO $ do
     alloca $ \wPtr ->
       alloca $ \hPtr -> do
         -- TODO: handle errors

--- a/src/SDL/TTF/Internals.hsc
+++ b/src/SDL/TTF/Internals.hsc
@@ -1,0 +1,35 @@
+module SDL.TTF.Internals where
+
+import Foreign.C.String
+import Foreign.C.Types (CInt)
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Utils
+import Foreign.Storable
+import Foreign.Ptr
+import Control.Monad
+
+import qualified SDL as SDL
+import qualified SDL.Raw as Raw
+
+--import SDL.TTF.FFI (TTFFont)
+import qualified SDL.TTF.FFI as FFI
+import SDL.TTF.Types
+
+peekInts 
+  :: (FFI.TTFFont -> CString -> Ptr CInt -> Ptr CInt -> IO CInt)
+  -> FFI.TTFFont
+  -> String
+  -> IO (Int,Int)
+peekInts fn fontPtr text = do
+    alloca $ \wPtr ->
+      alloca $ \hPtr -> do
+        -- TODO: handle errors
+        void $ withCString text $ \cstr -> fn fontPtr cstr wPtr hPtr
+        w <- peek wPtr
+        h <- peek hPtr
+        return (fromIntegral w, fromIntegral h)
+
+-- | Straight from the code of "sdl2" package, which is not exported. It will make a high level Surface from a Raw Surface. I will move this to somewhere safe, soon
+unmanagedSurface :: Ptr Raw.Surface -> SDL.Surface
+unmanagedSurface s = SDL.Surface s Nothing
+

--- a/src/SDL/TTF/Types.hsc
+++ b/src/SDL/TTF/Types.hsc
@@ -1,6 +1,6 @@
 #include "SDL2/SDL_ttf.h"
 {-# LANGUAGE EmptyDataDecls #-}
-module Graphics.UI.SDL.TTF.Types where
+module SDL.TTF.Types where
 
 data KerningStatus
   = KerningOn

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: nightly-2015-09-24
+resolver: lts-4.1


### PR DESCRIPTION
Note that I used the more restrictive BSD3 on my fork(OK, right?), but that is for using in my project, just in case the original is not maintained. You can remove it if you want to merge.

I also changed the stack.yaml just for convenience. 

Basically, the new API shields the end developer from using FFI directly, at least on the usage of core sdl2 package. The TTF library itself still uses pointers.
